### PR TITLE
toil(docs pip): fix broken links

### DIFF
--- a/docs/pip.md
+++ b/docs/pip.md
@@ -251,7 +251,7 @@ Note that if at least one dependency in your requirements file uses `--hash`,
 pip requires hashes for all dependencies. Use `pip-compile --generate-hashes` to
 generate compliant requirements files.
 
-*Hermeto does not support PEP 440 hashes in the url fragment, only --hash
+*Hermeto does not support PEP 440 hashes in the url fragment, only `--hash`
 options.*
 
 #### git urls
@@ -492,8 +492,8 @@ hermeto-output/deps/pip
 ```
 
 To make pip use the downloaded archives, use the [`--find-links`][] and
-[`--no-index`][] options. The --find-links option tells pip to look for
-dependency archives in a directory, --no-index prevents pip from preferring PyPI
+[`--no-index`][] options. The `--find-links` option tells pip to look for
+dependency archives in a directory, `--no-index` prevents pip from preferring PyPI
 over the local directory. Pip also accepts environment variables; Hermeto
 generates `PIP_FIND_LINKS` and `PIP_NO_INDEX` for you.
 See [Example: Generate environment variables](#generate-environment-variables)
@@ -778,12 +778,12 @@ Note that the repo also contains a `build.sh` script which will execute all of
 these steps for you.
 
 [`--find-links`]: https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-f
+[`--index-url`]: https://pip.pypa.io/en/stable/cli/pip_install/#install-index-url
 [`--no-binary`]: https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-no-binary
 [`--no-index`]: https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-no-index
-[`--use-pep517`]: https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-use-pep517
-[`--index-url`]: https://pip.pypa.io/en/stable/cli/pip_install/#install-index-url
 [`--require-hashes`]: https://pip.pypa.io/en/stable/cli/pip_install/#install-require-hashes
 [`--trusted-host`]: https://pip.pypa.io/en/stable/cli/pip/#trusted-host
+[`--use-pep517`]: https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-use-pep517
 [a `.netrc` file]: https://pip.pypa.io/en/stable/topics/authentication/#netrc-support
 [basic pip project]: https://github.com/hermetoproject/doc-examples/tree/pip-basic
 [binary format]: https://packaging.python.org/en/latest/specifications/binary-distribution-format

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,58 @@
+/* Custom h5 styling for Hermeto docs */
+.md-typeset h5 {
+  color: var(--md-primary-fg-color, #2e7d32);
+  font-size: 1.1em;
+  font-weight: 600;
+  margin: 1.5em 0 0.75em;
+  padding-bottom: 0.25em;
+  border-bottom: 2px solid rgba(46, 125, 50, 0.2);
+  letter-spacing: 0;
+}
+
+/* Responsive adjustments */
+@media screen and (max-width: 60em) {
+  .md-typeset h5 {
+    font-size: 1.05em;
+    margin: 1.25em 0 0.5em;
+  }
+}
+
+/* Dark theme adjustments */
+[data-md-color-scheme="slate"] .md-typeset h5 {
+  color: #81c784;
+  border-bottom-color: rgba(129, 199, 132, 0.3);
+}
+
+/* Ensure links in h5 render as links */
+.md-typeset h5 a {
+  color: var(--md-accent-fg-color, #4caf50) !important;
+  text-decoration: underline !important;
+}
+
+.md-typeset h5 a:hover {
+  color: var(--md-accent-fg-color--light, #66bb6a) !important;
+}
+
+[data-md-color-scheme="slate"] .md-typeset h5 a {
+  color: #81c784 !important;
+}
+
+[data-md-color-scheme="slate"] .md-typeset h5 a:hover {
+  color: #a5d6a7 !important;
+}
+
+/* Ensure code/backticks in h5 render as monospace */
+.md-typeset h5 code {
+  font-family: var(--md-code-font, "Roboto Mono", monospace) !important;
+  font-size: 0.9em;
+  background-color: var(--md-code-bg-color, rgba(0, 0, 0, 0.05)) !important;
+  padding: 0.1em 0.25em;
+  border-radius: 0.2em;
+  color: var(--md-code-fg-color, #e91e63) !important;
+  font-weight: 400 !important;
+}
+
+[data-md-color-scheme="slate"] .md-typeset h5 code {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  color: #f8bbd0 !important;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,14 @@ markdown_extensions:
   - toc:
       permalink: true
   - footnotes
+  - def_list
+  - attr_list
+  - md_in_html
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
 
 # Markdown validation
 validation:


### PR DESCRIPTION
mkdocs-material is styled to render h5 links where the name contains any formatting (like [--find-links][] or even [--find-links][]) brokenly.

This PR attempts to remedy that, using CSS overrides.

Signed-off-by: Ben Alkov [ben.alkov@redhat.com](mailto:ben.alkov@redhat.com)

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
